### PR TITLE
Don't add max-width to images with width="auto"

### DIFF
--- a/lib/html/pipeline/image_max_width_filter.rb
+++ b/lib/html/pipeline/image_max_width_filter.rb
@@ -9,9 +9,8 @@ module HTML
     class ImageMaxWidthFilter < Filter
       def call
         doc.search('img').each do |element|
-          # Skip if there's already a style attribute. Not sure how this
-          # would happen but we can reconsider it in the future.
-          next if element['style']
+          # Skip if there's already a style attribute or width attribute set to auto.
+          next if element['style'] || element['width'] == 'auto'
 
           # Bail out if src doesn't look like a valid http url. trying to avoid weird
           # js injection via javascript: urls.


### PR DESCRIPTION
Bail out if the image tag already has a width attribute set to auto.

The use case is when images in a table should all have the same height but an
automatic width, causing scrollbars to appear for the table. I tried everything
I could think of and search for in the README linked below, but the only hack I
could come up with was to add variable amounts of `&nbsp;` characters in the
table header cells to force the cell width large enough to accommodate the
images.

https://github.com/karlhorky/javascript-graphs/blob/master/README.md
