### PR TITLE
Allow tel: URIs

### DIFF
--- a/lib/html/pipeline/sanitization_filter.rb
+++ b/lib/html/pipeline/sanitization_filter.rb
@@ -37,7 +37,7 @@ module HTML
       TABLE_SECTIONS = Set.new(%w(thead tbody tfoot).freeze)
 
       # These schemes are the only ones allowed in <a href> attributes by default.
-      ANCHOR_SCHEMES = ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac'].freeze
+      ANCHOR_SCHEMES = ['http', 'https', 'mailto', 'tel', :relative, 'github-windows', 'github-mac'].freeze
 
       # The main sanitization whitelist. Only these elements and attributes are
       # allowed through by default.

--- a/test/html/pipeline/sanitization_filter_test.rb
+++ b/test/html/pipeline/sanitization_filter_test.rb
@@ -102,7 +102,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_whitelist_contains_default_anchor_schemes
-    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::WHITELIST[:protocols]['a']['href'], ['http', 'https', 'mailto', 'tel', :relative, 'github-windows', 'github-mac']
   end
 
   def test_whitelist_from_full_constant
@@ -113,7 +113,7 @@ class HTML::Pipeline::SanitizationFilterTest < Minitest::Test
   end
 
   def test_exports_default_anchor_schemes
-    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', :relative, 'github-windows', 'github-mac']
+    assert_equal SanitizationFilter::ANCHOR_SCHEMES, ['http', 'https', 'mailto', 'tel', :relative, 'github-windows', 'github-mac']
   end
 
   def test_script_contents_are_removed


### PR DESCRIPTION
Shouldn't tel: links be allowed?
Relevant standard: http://tools.ietf.org/html/rfc3966

I'm submitting this request because I would like to use tel: links within Github wikis.
