### PR TITLE
Use `node.text` instead of `node.to_html` in mention-filters

### DIFF
--- a/lib/html/pipeline/@mention_filter.rb
+++ b/lib/html/pipeline/@mention_filter.rb
@@ -73,7 +73,7 @@ module HTML
         result[:mentioned_usernames] ||= []
 
         doc.search('.//text()').each do |node|
-          content = node.to_html
+          content = node.text
           next unless content.include?('@')
           next if has_ancestor?(node, IGNORE_PARENTS)
           html = mention_link_filter(content, base_url, info_url, username_pattern)

--- a/lib/html/pipeline/@team_mention_filter.rb
+++ b/lib/html/pipeline/@team_mention_filter.rb
@@ -53,7 +53,7 @@ module HTML
         result[:mentioned_teams] ||= []
 
         doc.search('.//text()').each do |node|
-          content = node.to_html
+          content = node.text
           next unless content.include?('@')
           next if has_ancestor?(node, IGNORE_PARENTS)
           html = mention_link_filter(content, base_url, team_pattern)


### PR DESCRIPTION
Because
- the filters are only doing simple text substitution on the inner-text.
- calls `:to_html` involves allocating and empty `options` hash on each node.
- already in use by similar filter (`emoji_filter`):
  https://github.com/jch/html-pipeline/blob/8f9e95fa7b1af0410092d8f0a908c977b00989ac/lib/html/pipeline/emoji_filter.rb#L18-L28