### PR TITLE
Support multiple dependencies per filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,7 @@ end
 
 group :test do
   gem 'commonmarker', '~> 0.16', require: false
-  gem 'email_reply_parser', '~> 0.5', require: false
-  gem 'gemoji', '~> 2.0', require: false
+  gem 'gemoji', '~> 3.0', require: false
   gem 'minitest'
   gem 'rinku',              '~> 1.7', require: false
   gem 'sanitize',           '~> 5.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ group :test do
   gem 'gemoji', '~> 3.0', require: false
   gem 'gemojione', '~> 4.3', require: false
   gem 'minitest'
-  gem 'minitest-stub_any_instance'
   gem 'rinku',              '~> 1.7', require: false
   gem 'sanitize',           '~> 5.2', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 group :test do
   gem 'commonmarker', '~> 0.16', require: false
   gem 'gemoji', '~> 3.0', require: false
+  gem 'gemojione', '~> 4.3', require: false
   gem 'minitest'
   gem 'rinku',              '~> 1.7', require: false
   gem 'sanitize',           '~> 5.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in html-pipeline.gemspec
 gemspec
 
-group :development, :test do
-  gem 'awesome_print'
+gem 'awesome_print'
 
-  gem 'rubocop'
-  gem 'rubocop-performance'
-  gem 'rubocop-standard'
-end
+gem 'rubocop'
+gem 'rubocop-performance'
+gem 'rubocop-standard'
 
 group :development do
   gem 'bundler'
@@ -23,6 +21,7 @@ group :test do
   gem 'gemoji', '~> 3.0', require: false
   gem 'gemojione', '~> 4.3', require: false
   gem 'minitest'
+  gem 'minitest-stub_any_instance'
   gem 'rinku',              '~> 1.7', require: false
   gem 'sanitize',           '~> 5.2', require: false
 

--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -57,24 +57,34 @@ module HTML
     def self.require_dependencies(names, requirer)
       dependency_list = names.dup
       loaded = false
+
       while !loaded && names.length > 1
         name = names.shift
+
         begin
           require_dependency(name, requirer)
           loaded = true # we got a dependency
+          define_dependency_loaded_method(name, true)
         # try the next dependency
-        rescue MissingDependencyError # rubocop:disable Lint/SuppressedException
+        rescue MissingDependencyError
+          define_dependency_loaded_method(name, false)
         end
       end
 
       return if loaded
 
       begin
-        require names.shift
+        name = names.shift
+        require name
+        define_dependency_loaded_method(name, true)
       rescue LoadError => e
         raise MissingDependencyError,
               "Missing all dependencies '#{dependency_list.join(', ')}' for #{requirer}. See README.md for details.\n#{e.class.name}: #{e}"
       end
+    end
+
+    def self.define_dependency_loaded_method(name, value)
+      self.class.define_method :"#{name}_loaded?", -> { value }
     end
 
     # Our DOM implementation.

--- a/lib/html/pipeline.rb
+++ b/lib/html/pipeline.rb
@@ -54,6 +54,29 @@ module HTML
             "Missing dependency '#{name}' for #{requirer}. See README.md for details.\n#{e.class.name}: #{e}"
     end
 
+    def self.require_dependencies(names, requirer)
+      dependency_list = names.dup
+      loaded = false
+      while !loaded && names.length > 1
+        name = names.shift
+        begin
+          require_dependency(name, requirer)
+          loaded = true # we got a dependency
+        # try the next dependency
+        rescue MissingDependencyError # rubocop:disable Lint/SuppressedException
+        end
+      end
+
+      return if loaded
+
+      begin
+        require names.shift
+      rescue LoadError => e
+        raise MissingDependencyError,
+              "Missing all dependencies '#{dependency_list.join(', ')}' for #{requirer}. See README.md for details.\n#{e.class.name}: #{e}"
+      end
+    end
+
     # Our DOM implementation.
     DocumentFragment = Nokogiri::HTML::DocumentFragment
 

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -82,12 +82,12 @@ module HTML
       end
 
       # Build a regexp that matches all valid :emoji: names.
-      def self.emoji_pattern
+      def emoji_pattern
         @emoji_pattern ||= /:(#{emoji_names.map { |name| Regexp.escape(name) }.join('|')}):/
       end
 
-      def self.emoji_names
-        if gemoji_loaded?
+      def emoji_names
+        if self.class.gemoji_loaded?
           Emoji.all.map(&:aliases)
         else
           Gemojione::Index.new.all.map { |i| i[1]['name'] }
@@ -109,10 +109,6 @@ module HTML
 
       private def emoji_url(name)
         File.join(asset_root, asset_path(name))
-      end
-
-      private def emoji_pattern
-        self.class.emoji_pattern
       end
 
       private def emoji_filename(name)

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -41,7 +41,7 @@ module HTML
       #
       # Returns a String with :emoji: replaced with images.
       def emoji_image_filter(text)
-        text.gsub(emoji_pattern) do |_match|
+        text.gsub(emoji_pattern) do
           emoji_image_tag(Regexp.last_match(1))
         end
       end
@@ -87,7 +87,11 @@ module HTML
       end
 
       def self.emoji_names
-        Emoji.all.map(&:aliases).flatten.sort
+        if gemoji_loaded?
+          Emoji.all.map(&:aliases)
+        else
+          Gemojione::Index.new.all.map { |i| i[1]['name'] }
+        end.flatten.sort
       end
 
       # Default attributes for img tag
@@ -112,7 +116,12 @@ module HTML
       end
 
       private def emoji_filename(name)
-        Emoji.find_by_alias(name).image_filename
+        if self.class.gemoji_loaded?
+          Emoji.find_by_alias(name).image_filename
+        else
+          # replace their asset_host with ours
+          Gemojione.image_url_for_name(name).sub(Gemojione.asset_host, '')
+        end
       end
 
       # Return ancestor tags to stop the emojification.

--- a/lib/html/pipeline/emoji_filter.rb
+++ b/lib/html/pipeline/emoji_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
-HTML::Pipeline.require_dependency('gemoji', 'EmojiFilter')
+HTML::Pipeline.require_dependencies(%w[gemoji gemojione], 'EmojiFilter')
 
 module HTML
   class Pipeline

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -93,4 +93,26 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
+
+  def test_works_with_gemoji
+    require 'gemojione'
+
+    EmojiFilter.stub :gemoji_loaded?, false do
+      body = ':flag_ar:'
+      filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+      doc = filter.call
+      assert_equal %(<img class="emoji" title=":flag_ar:" alt=":flag_ar:" src="https://foo.com/emoji/1f1e6-1f1f7.png" height="20" width="20" align="absmiddle">), doc.to_html
+    end
+  end
+
+  def test_gemoji_can_accept_symbolized_keys
+    require 'gemojione'
+
+    EmojiFilter.stub :gemoji_loaded?, false do
+      body = ':flag_ar:'
+      filter = EmojiFilter.new(body, context: { asset_root: 'https://coolwebsite.com', img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil) })
+      doc = filter.call
+      assert_equal %(<img class="emoji" title=":flag_ar:" alt=":flag_ar:" src="https://coolwebsite.com/emoji/1f1e6-1f1f7.png" draggable="false">), doc.to_html
+    end
+  end
 end

--- a/test/html/pipeline/emoji_filter_test.rb
+++ b/test/html/pipeline/emoji_filter_test.rb
@@ -3,78 +3,80 @@
 require 'test_helper'
 
 class HTML::Pipeline::EmojiFilterTest < Minitest::Test
-  EmojiFilter = HTML::Pipeline::EmojiFilter
+  def setup
+    @emoji_filter = HTML::Pipeline::EmojiFilter
+  end
 
   def test_emojify
-    filter = EmojiFilter.new('<p>:shipit:</p>', context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new('<p>:shipit:</p>', context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_match 'https://foo.com/emoji/shipit.png', doc.search('img').attr('src').value
   end
 
   def test_uri_encoding
-    filter = EmojiFilter.new('<p>:+1:</p>', context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new('<p>:+1:</p>', context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_match 'https://foo.com/emoji/unicode/1f44d.png', doc.search('img').attr('src').value
   end
 
   def test_required_context_validation
     exception = assert_raises(ArgumentError) do
-      EmojiFilter.call('', context: {})
+      @emoji_filter.call('', context: {})
     end
     assert_match(/:asset_root/, exception.message)
   end
 
   def test_custom_asset_path
-    filter = EmojiFilter.new('<p>:+1:</p>', context: { asset_path: ':file_name', asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new('<p>:+1:</p>', context: { asset_path: ':file_name', asset_root: 'https://foo.com' })
     doc = filter.call
     assert_match 'https://foo.com/unicode/1f44d.png', doc.search('img').attr('src').value
   end
 
   def test_not_emojify_in_code_tags
     body = '<code>:shipit:</code>'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_equal body, doc.to_html
   end
 
   def test_not_emojify_in_tt_tags
     body = '<tt>:shipit:</tt>'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_equal body, doc.to_html
   end
 
   def test_not_emojify_in_pre_tags
     body = '<pre>:shipit:</pre>'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_equal body, doc.to_html
   end
 
   def test_not_emojify_in_custom_single_tag_foo
     body = '<foo>:shipit:</foo>'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com', ignored_ancestor_tags: %w[foo] })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com', ignored_ancestor_tags: %w[foo] })
     doc = filter.call
     assert_equal body, doc.to_html
   end
 
   def test_not_emojify_in_custom_multiple_tags_foo_and_bar
     body = '<bar>:shipit:</bar>'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com', ignored_ancestor_tags: %w[foo bar] })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com', ignored_ancestor_tags: %w[foo bar] })
     doc = filter.call
     assert_equal body, doc.to_html
   end
 
   def test_img_tag_attributes
     body = ':shipit:'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com' })
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
   end
 
   def test_img_tag_attributes_can_be_customized
     body = ':shipit:'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash('draggable' => 'false', 'height' => nil, 'width' => nil, 'align' => nil) })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash('draggable' => 'false', 'height' => nil, 'width' => nil, 'align' => nil) })
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
@@ -82,14 +84,14 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   def test_img_attrs_value_can_accept_proclike_object
     remove_colons = ->(name) { name.delete(':') }
     body = ':shipit:'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash('title' => remove_colons) })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash('title' => remove_colons) })
     doc = filter.call
     assert_equal %(<img class="emoji" title="shipit" alt=":shipit:" src="https://foo.com/emoji/shipit.png" height="20" width="20" align="absmiddle">), doc.to_html
   end
 
   def test_img_attrs_can_accept_symbolized_keys
     body = ':shipit:'
-    filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil) })
+    filter = @emoji_filter.new(body, context: { asset_root: 'https://foo.com', img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil) })
     doc = filter.call
     assert_equal %(<img class="emoji" title=":shipit:" alt=":shipit:" src="https://foo.com/emoji/shipit.png" draggable="false">), doc.to_html
   end
@@ -97,9 +99,9 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
   def test_works_with_gemoji
     require 'gemojione'
 
-    EmojiFilter.stub :gemoji_loaded?, false do
+    HTML::Pipeline::EmojiFilter.stub :gemoji_loaded?, false do
       body = ':flag_ar:'
-      filter = EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
+      filter = HTML::Pipeline::EmojiFilter.new(body, context: { asset_root: 'https://foo.com' })
       doc = filter.call
       assert_equal %(<img class="emoji" title=":flag_ar:" alt=":flag_ar:" src="https://foo.com/emoji/1f1e6-1f1f7.png" height="20" width="20" align="absmiddle">), doc.to_html
     end
@@ -107,10 +109,9 @@ class HTML::Pipeline::EmojiFilterTest < Minitest::Test
 
   def test_gemoji_can_accept_symbolized_keys
     require 'gemojione'
-
-    EmojiFilter.stub :gemoji_loaded?, false do
+    HTML::Pipeline::EmojiFilter.stub :gemoji_loaded?, false do
       body = ':flag_ar:'
-      filter = EmojiFilter.new(body, context: { asset_root: 'https://coolwebsite.com', img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil) })
+      filter = HTML::Pipeline::EmojiFilter.new(body, context: { asset_root: 'https://coolwebsite.com', img_attrs: Hash(draggable: false, height: nil, width: nil, align: nil) })
       doc = filter.call
       assert_equal %(<img class="emoji" title=":flag_ar:" alt=":flag_ar:" src="https://coolwebsite.com/emoji/1f1e6-1f1f7.png" draggable="false">), doc.to_html
     end

--- a/test/html/pipeline/require_helper_test.rb
+++ b/test/html/pipeline/require_helper_test.rb
@@ -3,8 +3,12 @@
 require 'test_helper'
 
 class HTML::Pipeline::RequireHelperTest < Minitest::Test
-  def test_works_with_existing
+  def test_works_with_existing_dependency
     HTML::Pipeline.require_dependency('rake', 'SomeClass')
+  end
+
+  def test_works_with_existing_dependencies
+    HTML::Pipeline.require_dependencies(%w[old_sql rake], 'SomeClass')
   end
 
   def test_raises_mising_dependency_error
@@ -13,11 +17,24 @@ class HTML::Pipeline::RequireHelperTest < Minitest::Test
     end
   end
 
-  def test_raises_error_including_message
+  def test_raises_mising_dependenccies_error
+    assert_raises HTML::Pipeline::MissingDependencyError do
+      HTML::Pipeline.require_dependencies(%w[non-existant something], 'SomeClass')
+    end
+  end
+
+  def test_raises_dependency_error_including_message
     error = assert_raises(HTML::Pipeline::MissingDependencyError) do
       HTML::Pipeline.require_dependency('non-existant', 'SomeClass')
     end
     assert_includes(error.message, "Missing dependency 'non-existant' for SomeClass. See README.md for details.")
+  end
+
+  def test_raises_dependencies_error_including_message
+    error = assert_raises(HTML::Pipeline::MissingDependencyError) do
+      HTML::Pipeline.require_dependencies(%w[non-existant something], 'SomeClass')
+    end
+    assert_includes(error.message, "Missing all dependencies 'non-existant, something' for SomeClass. See README.md for details.")
   end
 
   def test_raises_error_includes_underlying_message

--- a/test/html/pipeline/require_helper_test.rb
+++ b/test/html/pipeline/require_helper_test.rb
@@ -8,7 +8,9 @@ class HTML::Pipeline::RequireHelperTest < Minitest::Test
   end
 
   def test_works_with_existing_dependencies
-    HTML::Pipeline.require_dependencies(%w[old_sql rake], 'SomeClass')
+    HTML::Pipeline.require_dependencies(%w[old_sql nokogiri], 'SomeClass')
+    assert HTML::Pipeline.nokogiri_loaded?
+    refute HTML::Pipeline.old_sql_loaded?
   end
 
   def test_raises_mising_dependency_error

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,13 @@
 
 require 'bundler/setup'
 require 'html/pipeline'
+
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'minitest/focus'
+require 'minitest/stub_any_instance'
+
+require 'awesome_print'
 
 module TestHelpers
   # Asserts that two html fragments are equivalent. Attribute order

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require 'html/pipeline'
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'minitest/focus'
-require 'minitest/stub_any_instance'
 
 require 'awesome_print'
 


### PR DESCRIPTION
Closes https://github.com/gjtorikian/html-pipeline/issues/200.

Adds a new method, `require_dependencies`, which allows for the loading of multiple dependencies to satisfy a filter's needs. Once a dependency is found, a `#{name_loaded?}` method is generated, which is `true` for the matched dependency. This can then be used in the filter to account for differences in rendering logic.