### PR TITLE
handle invalid data urls in absolute source filter

### DIFF
--- a/lib/html/pipeline/absolute_source_filter.rb
+++ b/lib/html/pipeline/absolute_source_filter.rb
@@ -28,7 +28,12 @@ module HTML
                  else
                    image_subpage_url
                  end
-          element['src'] = URI.join(base, src).to_s
+
+          begin
+            element['src'] = URI.join(base, src).to_s
+          rescue Exception
+            next
+          end
         end
         doc
       end

--- a/test/html/pipeline/absolute_source_filter_test.rb
+++ b/test/html/pipeline/absolute_source_filter_test.rb
@@ -53,4 +53,12 @@ class HTML::Pipeline::AbsoluteSourceFilterTest < Minitest::Test
     end
     assert_match 'HTML::Pipeline::AbsoluteSourceFilter', exception.message
   end
+
+  def test_ignores_data_urls
+    orig = %(<p><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 696 391'%3E%3Crect x='0' y='0' width='696' height='391' fill='%23f2f2f2'%3E%3C/rect%3E%3C/svg%3E"></p>)
+    result = AbsoluteSourceFilter.call(orig, @options).to_s
+
+    expected = %(<p><img src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20696%20391'%3E%3Crect%20x='0'%20y='0'%20width='696'%20height='391'%20fill='%23f2f2f2'%3E%3C/rect%3E%3C/svg%3E"></p>)
+    assert_equal expected, result
+  end
 end


### PR DESCRIPTION
simply catch exceptions coming from URI.join like the camo filter does.
the truth is that arbitrary input can be mal-formatted, e.g.

```
URI::InvalidURIError: bad URI(is not URI?): "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='696px' height='391px' viewBox='0 0 696 391'%3E%3Crect x='0' y='0' width='696' height='391' fill='%23f2f2f2'%3E%3C/rect%3E%3C/svg%3E"
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/rfc3986_parser.rb:67:in `split'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/rfc3986_parser.rb:73:in `parse'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/rfc3986_parser.rb:117:in `convert_to_uri'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/generic.rb:1101:in `merge'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/rfc3986_parser.rb:89:in `inject'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/rfc3986_parser.rb:89:in `join'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/2.7.0/uri/common.rb:271:in `join'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/gems/2.7.0/gems/html-pipeline-2.14.0/lib/html/pipeline/absolute_source_filter.rb:31:in `block in call'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/gems/2.7.0/gems/nokogiri-1.13.6-x86_64-darwin/lib/nokogiri/xml/node_set.rb:234:in `block in each'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/gems/2.7.0/gems/nokogiri-1.13.6-x86_64-darwin/lib/nokogiri/xml/node_set.rb:233:in `upto'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/gems/2.7.0/gems/nokogiri-1.13.6-x86_64-darwin/lib/nokogiri/xml/node_set.rb:233:in `each'
    /usr/local/Cellar/rbenv/1.2.0/versions/2.7.4/lib/ruby/gems/2.7.0/gems/html-pipeline-2.14.0/lib/html/pipeline/absolute_source_filter.rb:22:in `call'
```