### PR TITLE
Replace EscapeUtils.escape_html with CGI.escape_html

### DIFF
--- a/lib/html/pipeline/email_reply_filter.rb
+++ b/lib/html/pipeline/email_reply_filter.rb
@@ -38,7 +38,8 @@ module HTML
       def call
         found_hidden = nil
         paragraphs = EmailReplyParser.read(text.dup).fragments.map do |fragment|
-          pieces = [escape_html(fragment.to_s.strip).gsub(/^\s*(>|&gt;)/, '')]
+          pieces = [CGI.escapeHTML(fragment.to_s.strip).gsub(/^\s*(>|&gt;)/, '')]
+
           if fragment.quoted?
             if context[:hide_quoted_email_addresses]
               pieces.map! do |piece|

--- a/lib/html/pipeline/plain_text_input_filter.rb
+++ b/lib/html/pipeline/plain_text_input_filter.rb
@@ -8,7 +8,7 @@ module HTML
     # in a div.
     class PlainTextInputFilter < TextFilter
       def call
-        "<div>#{EscapeUtils.escape_html(@text, false)}</div>"
+        "<div>#{CGI.escape_html(@text)}</div>"
       end
     end
   end

--- a/lib/html/pipeline/toc_filter.rb
+++ b/lib/html/pipeline/toc_filter.rb
@@ -47,7 +47,7 @@ module HTML
           uniq = headers[id] > 0 ? "-#{headers[id]}" : ''
           headers[id] += 1
           if header_content = node.children.first
-            result[:toc] << %(<li><a href="##{id}#{uniq}">#{EscapeUtils.escape_html(text)}</a></li>\n)
+            result[:toc] << %(<li><a href="##{id}#{uniq}">#{CGI.escape_html(text)}</a></li>\n)
             header_content.add_previous_sibling(%(<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}" aria-hidden="true">#{anchor_icon}</a>))
           end
         end

--- a/test/html/pipeline/email_reply_filter_test.rb
+++ b/test/html/pipeline/email_reply_filter_test.rb
@@ -59,7 +59,7 @@ EMAIL
 <div class="email-quoted-reply">  *  Do you need -DCMAKE_SYSTEM_PROCESSOR=x86?</div>
 <div class="email-fragment">Yes, this is a bit dumb, but vc checks for that (or amd) to determine that it&#39;s not being built on ARM.</div>
 <span class="email-hidden-toggle"><a href="#">&hellip;</a></span><div class="email-hidden-reply" style="display:none"><div class="email-signature-reply">--
-Boaty McBoatface | http:&#47;&#47;example.org</div>
+Boaty McBoatface | http://example.org</div>
 </div>
 EXPECTED
 

--- a/test/html/pipeline/syntax_highlight_filter_test.rb
+++ b/test/html/pipeline/syntax_highlight_filter_test.rb
@@ -53,13 +53,13 @@ class HTML::Pipeline::SyntaxHighlightFilterTest < Minitest::Test
 
   def test_highlight_handles_nested_pre_tags
     inner_code = "<pre>console.log('i am nested!')</pre>"
-    escaped = EscapeUtils.escape_html(inner_code)
+    escaped = CGI.escape_html(inner_code)
     html = "<pre lang='html'>#{escaped}</pre>"
     filter = SyntaxHighlightFilter.new html, highlight: 'html'
 
     doc = filter.call
 
     assert_equal 2, doc.css('span[class=nt]').length
-    assert_equal EscapeUtils.unescape_html(escaped), doc.inner_text
+    assert_equal CGI.unescape_html(escaped), doc.inner_text
   end
 end


### PR DESCRIPTION
`EscapeUtils.escape_html` was deprecated in https://github.com/brianmario/escape_utils/commit/0da0c0a80017a18b2e007921782e83c8b94e6c41 and later removed.

Regarding drop of `/` escape please see the above commit: _“there's no reason to escape for slashes `/` in 2022.”_

This commit makes the test suite green again.