### PR TITLE
Have Zeitwerk not automatically load filters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,25 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: "09:00"
       timezone: "Etc/UTC"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
 
-  - package-ecosystem: "bundler"
+  - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
       time: "09:00"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 10
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 
 pipeline = HTMLPipeline.new(
   text_filters: [HelloJohnnyFilter.new]
-  convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new),
+  convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
     # note: next line is not needed as sanitization occurs by default;
     # see below for more info
   sanitization_config: HTMLPipeline::SanitizationFilter::DEFAULT_CONFIG,
@@ -126,8 +126,8 @@ context = {
 
 # Pipeline used for user provided content on the web
 MarkdownPipeline = HTMLPipeline.new (
-  text_filters: [HTMLPipeline::TextFilter::ImageMaxWidthFilter.new],
-  convert_filter: [HTMLPipeline::ConvertFilter::MarkdownFilter.new],
+  text_filters: [HTMLPipeline::TextFilter::ImageFilter.new],
+  convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
   node_filters: [
     HTMLPipeline::NodeFilter::HttpsFilter.new,HTMLPipeline::NodeFilter::MentionFilter.new,
   ], context: context)
@@ -137,7 +137,7 @@ MarkdownPipeline = HTMLPipeline.new (
 HtmlEmailPipeline = HTMLPipeline.new(
   text_filters: [
     PlainTextInputFilter.new,
-    ImageMaxWidthFilter.new
+    ImageFilter.new
   ], {})
 ```
 
@@ -173,7 +173,7 @@ pipeline = HTMLPipeline.new \
   text_filters: [
     HTMLPipeline::MarkdownFilter,
   ],
-  convert_filter: [HTMLPipeline::ConvertFilter::MarkdownFilter.new],
+  convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
   sanitization_config: ALLOWLIST
 
 result = pipeline.call <<-CODE
@@ -201,7 +201,7 @@ pipeline = HTMLPipeline.new \
   text_filters: [
     HTMLPipeline::MarkdownFilter,
   ],
-  convert_filter: [HTMLPipeline::ConvertFilter::MarkdownFilter.new],
+  convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
   sanitization_config: nil
 ```
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ gem "rouge"
 
 When developing a custom filter, call `HTMLPipeline.require_dependency` at the start to ensure that the local machine has the necessary dependency. You can also use `HTMLPipeline.require_dependencies` to provide a list of dependencies to check.
 
+On a similar note, you must manually require whichever filters you desire:
+
+```ruby
+require "html_pipeline" # must be included
+require "html_pipeline/convert_filter/markdown_filter" # included because you want to use this filter
+require "html_pipeline/node_filter/mention_filter" # included because you want to use this filter
+```
+
 ## Documentation
 
 Full reference documentation can be [found here](http://rubydoc.info/gems/html-pipeline/frames).

--- a/lib/html_pipeline.rb
+++ b/lib/html_pipeline.rb
@@ -2,10 +2,15 @@
 
 require "zeitwerk"
 lib_dir = File.join(File.dirname(__dir__), "lib")
+lib_html_pipeline_dir = File.join(File.dirname(__dir__), "lib", "html_pipeline")
 gem_loader = Zeitwerk::Loader.for_gem
 gem_loader.inflector.inflect(
   "html_pipeline" => "HTMLPipeline",
 )
+
+gem_loader.ignore(File.join(lib_html_pipeline_dir, "convert_filter"))
+gem_loader.ignore(File.join(lib_html_pipeline_dir, "node_filter"))
+gem_loader.ignore(File.join(lib_html_pipeline_dir, "text_filter"))
 gem_loader.ignore(File.join(lib_dir, "html-pipeline.rb"))
 gem_loader.setup
 

--- a/lib/html_pipeline/node_filter/emoji_filter.rb
+++ b/lib/html_pipeline/node_filter/emoji_filter.rb
@@ -17,7 +17,7 @@ class HTMLPipeline
 
       # Build a regexp that matches all valid :emoji: names.
       def after_initialize
-        @emoji_pattern ||= /:(#{emoji_names.map { |name| Regexp.escape(name) }.join('|')}):/
+        @emoji_pattern ||= /:(#{emoji_names.map { |name| Regexp.escape(name) }.join("|")}):/
       end
 
       def selector

--- a/lib/html_pipeline/version.rb
+++ b/lib/html_pipeline/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HTMLPipeline
-  VERSION = "3.0.0.pre5"
+  VERSION = "3.0.0.pre6"
 end

--- a/test/html_pipeline/convert_filter/markdown_filter_test.rb
+++ b/test/html_pipeline/convert_filter/markdown_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/convert_filter/markdown_filter"
 
 MarkdownFilter = HTMLPipeline::ConvertFilter::MarkdownFilter
 

--- a/test/html_pipeline/node_filter/absolute_source_filter_test.rb
+++ b/test/html_pipeline/node_filter/absolute_source_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/absolute_source_filter"
 
 AbsoluteSourceFilter = HTMLPipeline::NodeFilter::AbsoluteSourceFilter
 class HTMLPipeline

--- a/test/html_pipeline/node_filter/asset_proxy_filter_test.rb
+++ b/test/html_pipeline/node_filter/asset_proxy_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/asset_proxy_filter"
 
 class HTMLPipeline
   class AssetProxyFilterTest < Minitest::Spec

--- a/test/html_pipeline/node_filter/emoji_filter_test.rb
+++ b/test/html_pipeline/node_filter/emoji_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/emoji_filter"
 
 EmojiFilterFilter = HTMLPipeline::NodeFilter::EmojiFilter
 class HTMLPipeline

--- a/test/html_pipeline/node_filter/https_filter_test.rb
+++ b/test/html_pipeline/node_filter/https_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/https_filter"
 
 HttpsFilter = HTMLPipeline::NodeFilter::HttpsFilter
 

--- a/test/html_pipeline/node_filter/syntax_highlight_filter_test.rb
+++ b/test/html_pipeline/node_filter/syntax_highlight_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/syntax_highlight_filter"
 
 SyntaxHighlightFilter = HTMLPipeline::NodeFilter::SyntaxHighlightFilter
 

--- a/test/html_pipeline/node_filter/table_of_contents_filter_test.rb
+++ b/test/html_pipeline/node_filter/table_of_contents_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/table_of_contents_filter"
 
 class HTMLPipeline
   class NodeFilter

--- a/test/html_pipeline/node_filter/team_mention_filter_test.rb
+++ b/test/html_pipeline/node_filter/team_mention_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/team_mention_filter"
 
 class HTMLPipeline
   class TeamMentionFilterTest < Minitest::Test

--- a/test/html_pipeline/text_filter/image_filter_test.rb
+++ b/test/html_pipeline/text_filter/image_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/text_filter/image_filter"
 
 ImageFilter = HTMLPipeline::TextFilter::ImageFilter
 

--- a/test/html_pipeline/text_filter/plain_text_input_filter_test.rb
+++ b/test/html_pipeline/text_filter/plain_text_input_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/text_filter/plain_text_input_filter"
 
 class HTMLPipeline
   class PlainTextInputFilterTest < Minitest::Test

--- a/test/html_pipeline_test.rb
+++ b/test/html_pipeline_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "helpers/mocked_instrumentation_service"
+require "html_pipeline/node_filter/image_max_width_filter"
 
 class HTMLPipelineTest < Minitest::Test
   def setup

--- a/test/sanitization_filter_test.rb
+++ b/test/sanitization_filter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "html_pipeline/node_filter/mention_filter"
 
 class HTMLPipeline
   class SanitizationFilterTest < Minitest::Test


### PR DESCRIPTION
This causes problems if the underlying filter is not called, because Zeitwerk attempts to laod the required dependencies

cf https://github.com/fxn/zeitwerk#use-case-the-adapter-pattern