### PR TITLE
Handle odd numbers of NodeFilters to be configured

### DIFF
--- a/lib/html_pipeline.rb
+++ b/lib/html_pipeline.rb
@@ -178,7 +178,7 @@ class HTMLPipeline
       end
     end
 
-    @node_filters.collect(&:result).reduce(result, :merge)
+    result = result.merge(@node_filters.collect(&:result).reduce({}, :merge))
     @node_filters.each(&:reset!)
 
     result

--- a/lib/html_pipeline.rb
+++ b/lib/html_pipeline.rb
@@ -178,7 +178,7 @@ class HTMLPipeline
       end
     end
 
-    result = result.merge(Hash[*@node_filters.collect(&:result).flatten])
+    @node_filters.collect(&:result).reduce(result, :merge)
     @node_filters.each(&:reset!)
 
     result

--- a/lib/html_pipeline/version.rb
+++ b/lib/html_pipeline/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class HTMLPipeline
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end


### PR DESCRIPTION
The previous method of merging the results from the NodeFilter instances was breaking because Ruby was treating it as a series of 2-element arrays.

If you had 0, 1 or 2 node filters configured, it would work fine; if you added a third, it would break with an `ArgumentError`. Adding a fourth makes it work again.

Fixes #388