### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class HelloJohnnyFilter < HTMLPipelineFilter
 end
 
 pipeline = HTMLPipeline.new(
-  text_filters: [HelloJohnnyFilter.new]
+  text_filters: [HelloJohnnyFilter]
   convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
     # note: next line is not needed as sanitization occurs by default;
     # see below for more info
@@ -126,7 +126,7 @@ context = {
 
 # Pipeline used for user provided content on the web
 MarkdownPipeline = HTMLPipeline.new (
-  text_filters: [HTMLPipeline::TextFilter::ImageFilter.new],
+  text_filters: [HTMLPipeline::TextFilter::ImageFilter],
   convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
   node_filters: [
     HTMLPipeline::NodeFilter::HttpsFilter.new,HTMLPipeline::NodeFilter::MentionFilter.new,
@@ -136,8 +136,8 @@ MarkdownPipeline = HTMLPipeline.new (
 # processing also.
 HtmlEmailPipeline = HTMLPipeline.new(
   text_filters: [
-    PlainTextInputFilter.new,
-    ImageFilter.new
+    PlainTextInputFilter,
+    ImageFilter
   ], {})
 ```
 


### PR DESCRIPTION
An error will occur if new is added to the class specified for text_filters.

Reading the source code, it appears that specifying the class is the correct behavior, so I changed the README.


## Example 

```ruby
require 'html_pipeline'
require 'html_pipeline/text_filter/image_filter'
pipeline = HTMLPipeline.new(text_filters: [HTMLPipeline::TextFilter::ImageFilter.new])

```

```
lib/html_pipeline/text_filter.rb:7:in `initialize': wrong number of arguments (given 0, expected 1) (ArgumentError)
```