### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ you to add additional elements. You can either modify the constant's value, or
 re-define your own config and pass that in, such as:
 
 ```ruby
-config = HTMLPipeline::SanitizerFilter::DEFAULT_CONFIG.dup
+config = HTMLPipeline::SanitizationFilter::DEFAULT_CONFIG.dup
 config[:elements] << "iframe" # sure, whatever you want
 ```
 


### PR DESCRIPTION
## Example

```
config = HTMLPipeline::SanitizerFilter::DEFAULT_CONFIG.dup
config[:elements] << "iframe" # sure, whatever you want
```

```
uninitialized constant HTMLPipeline::SanitizerFilter (NameError)
Did you mean?  HTMLPipeline::SanitizationFilter
```