### PR TITLE
UPGRADING: `TextFilter` not removed

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,10 +14,8 @@ The following filters were removed:
 
 - `AutolinkFilter`: this is handled by [Commonmarker](https://www.github.com/gjtorikian/commonmarker) and can be disabled/enabled through the `MarkdownFilter`'s `context` hash
 - `SanitizationFilter`: this is handled by [Selma](https://www.github.com/gjtorikian/selma); configuration can be done through the `sanitization_config` hash
-
 - `EmailReplyFilter`
 - `CamoFilter`
-- `TextFilter`
 
 ### Changed API
 


### PR DESCRIPTION
Still exist here? https://github.com/gjtorikian/html-pipeline/blob/v3.0.3/lib/html_pipeline/text_filter.rb#L4