### PR TITLE
Add support for @ prefix on MentionFilter base_url

### DIFF
--- a/lib/html_pipeline/node_filter/mention_filter.rb
+++ b/lib/html_pipeline/node_filter/mention_filter.rb
@@ -115,7 +115,8 @@ class HTMLPipeline
         result[:mentioned_usernames] |= [login]
 
         url = base_url.dup
-        url << "/" unless %r{[/~]\z}.match?(url)
+        excluded_prefixes = [%r{[/~]\z}, %r{[/@]\z}]
+        url << "/" unless excluded_prefixes.any? { |excluded_prefix| excluded_prefix.match?(url) }
 
         "<a href=\"#{url << login}\" class=\"user-mention\">" \
           "@#{login}" \

--- a/lib/html_pipeline/node_filter/mention_filter.rb
+++ b/lib/html_pipeline/node_filter/mention_filter.rb
@@ -115,8 +115,8 @@ class HTMLPipeline
         result[:mentioned_usernames] |= [login]
 
         url = base_url.dup
-        excluded_prefixes = [%r{[/~]\z}, %r{[/@]\z}]
-        url << "/" unless excluded_prefixes.any? { |excluded_prefix| excluded_prefix.match?(url) }
+        excluded_prefixes = %r{[/(?:~|@]\z}
+        url << "/" unless excluded_prefixes.match?(url)
 
         "<a href=\"#{url << login}\" class=\"user-mention\">" \
           "@#{login}" \

--- a/lib/html_pipeline/node_filter/team_mention_filter.rb
+++ b/lib/html_pipeline/node_filter/team_mention_filter.rb
@@ -94,8 +94,8 @@ class HTMLPipeline
         result[:mentioned_teams] |= [team]
 
         url = base_url.dup
-        excluded_prefixes = [%r{[/~]\z}, %r{[/@]\z}]
-        url << "/" unless excluded_prefixes.any? { |excluded_prefix| excluded_prefix.match?(url) }
+        excluded_prefixes = %r{[/(?:~|@]\z}
+        url << "/" unless excluded_prefixes.match?(url)
 
         "<a href=\"#{url << org}/#{team}\" class=\"team-mention\">" \
           "@#{org}/#{team}" \

--- a/lib/html_pipeline/node_filter/team_mention_filter.rb
+++ b/lib/html_pipeline/node_filter/team_mention_filter.rb
@@ -94,7 +94,8 @@ class HTMLPipeline
         result[:mentioned_teams] |= [team]
 
         url = base_url.dup
-        url << "/" unless %r{[/~]\z}.match?(url)
+        excluded_prefixes = [%r{[/~]\z}, %r{[/@]\z}]
+        url << "/" unless excluded_prefixes.any? { |excluded_prefix| excluded_prefix.match?(url) }
 
         "<a href=\"#{url << org}/#{team}\" class=\"team-mention\">" \
           "@#{org}/#{team}" \

--- a/test/html_pipeline/node_filter/mention_filter_test.rb
+++ b/test/html_pipeline/node_filter/mention_filter_test.rb
@@ -105,6 +105,16 @@ class HTMLPipeline
       )
     end
 
+    def test_base_url_slash_with_at
+      body = "<p>Hi, @jch!</p>"
+      link = '<a href="/@jch" class="user-mention">@jch</a>'
+
+      assert_equal(
+        "<p>Hi, #{link}!</p>",
+        @filter.call(body, context: @context.merge({ base_url: "/@" })),
+      )
+    end
+
     def test_matches_usernames_in_body
       body = "@test how are you?"
 

--- a/test/html_pipeline/node_filter/team_mention_filter_test.rb
+++ b/test/html_pipeline/node_filter/team_mention_filter_test.rb
@@ -115,6 +115,16 @@ class HTMLPipeline
       )
     end
 
+    def test_base_url_slash_with_at
+      body = "<p>Hi, @github/team!</p>"
+      link = '<a href="/@github/team" class="team-mention">@github/team</a>'
+
+      assert_equal(
+        "<p>Hi, #{link}!</p>",
+        @filter.call(body, context: { base_url: "/@" }),
+      )
+    end
+
     def test_multiple_team_mentions
       body = "<p>Hi, @github/whale and @github/donut!</p>"
       link_whale = '<a href="/github/whale" class="team-mention">@github/whale</a>'


### PR DESCRIPTION
I had a situation where I wanted to use the `@` prefix on mention links with the `MentionFilter` (the way tilde is already supported). Example: `/@username`.

Currently, if you set the `base_url` like this: `base_url: "/@"`, then the link would be: `/@/username` and I don't want the slash between @ and username.

I've updated `MentionFilter#link_to_mentioned_user` and `TeamMentionFilter#link_to_mentioned_team` to support this, and added accompanying tests.

Additionally, I noticed that the regex `%r{[/~]\z}` will match strings like `~~~` and `////` and I'm wondering if that's intended? If not, I could change those checks to something like `url.ends_with?("/@")`.

Thanks for this gem! 😊