### PR TITLE
Possible bug when using both MentionFilter and TeamMentionFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,34 +343,6 @@ service.subscribe "call_text_filters.html_pipeline" do |event, start, ending, tr
 end
 ```
 
-## Third Party Extensions
-
-If you have an idea for a filter, propose it as
-[an issue](https://github.com/gjtorikian/html-pipeline/issues) first. This allows us to discuss
-whether the filter is a common enough use case to belong in this gem, or should be
-built as an external gem.
-
-Here are some extensions people have built:
-
-- [html-pipeline-asciidoc_filter](https://github.com/asciidoctor/html-pipeline-asciidoc_filter)
-- [jekyll-html-pipeline](https://github.com/gjtorikian/jekyll-html-pipeline)
-- [nanoc-html-pipeline](https://github.com/burnto/nanoc-html-pipeline)
-- [html-pipeline-bitly](https://github.com/dewski/html-pipeline-bitly)
-- [html-pipeline-cite](https://github.com/lifted-studios/html-pipeline-cite)
-- [tilt-html-pipeline](https://github.com/bradgessler/tilt-html-pipeline)
-- [html-pipeline-wiki-link'](https://github.com/lifted-studios/html-pipeline-wiki-link) - WikiMedia-style wiki links
-- [task_list](https://github.com/github/task_list) - GitHub flavor Markdown Task List
-- [html-pipeline-nico_link](https://github.com/rutan/html-pipeline-nico_link) - An HTMLPipeline filter for [niconico](http://www.nicovideo.jp) description links
-- [html-pipeline-gitlab](https://gitlab.com/gitlab-org/html-pipeline-gitlab) - This gem implements various filters for html-pipeline used by GitLab
-- [html-pipeline-youtube](https://github.com/st0012/html-pipeline-youtube) - An HTMLPipeline filter for YouTube links
-- [html-pipeline-flickr](https://github.com/st0012/html-pipeline-flickr) - An HTMLPipeline filter for Flickr links
-- [html-pipeline-vimeo](https://github.com/dlackty/html-pipeline-vimeo) - An HTMLPipeline filter for Vimeo links
-- [html-pipeline-hashtag](https://github.com/mr-dxdy/html-pipeline-hashtag) - An HTMLPipeline filter for hashtags
-- [html-pipeline-linkify_github](https://github.com/jollygoodcode/html-pipeline-linkify_github) - An HTMLPipeline filter to autolink GitHub urls
-- [html-pipeline-redcarpet_filter](https://github.com/bmikol/html-pipeline-redcarpet_filter) - Render Markdown source text into Markdown HTML using Redcarpet
-- [html-pipeline-typogruby_filter](https://github.com/bmikol/html-pipeline-typogruby_filter) - Add Typogruby text filters to your HTMLPipeline
-- [korgi](https://github.com/jodeci/korgi) - HTMLPipeline filters for links to Rails resources
-
 ## FAQ
 
 ### 1. Why doesn't my pipeline work when there's no root element in the document?

--- a/test/html_pipeline_test.rb
+++ b/test/html_pipeline_test.rb
@@ -202,7 +202,7 @@ class HTMLPipelineTest < Minitest::Test
       convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
       node_filters: [
         HTMLPipeline::NodeFilter::MentionFilter.new,
-        HTMLPipeline::NodeFilter::TeamMentionFilter.new
+        HTMLPipeline::NodeFilter::TeamMentionFilter.new,
       ],
     )
     result = pipeline.call(text)[:output]

--- a/test/html_pipeline_test.rb
+++ b/test/html_pipeline_test.rb
@@ -194,4 +194,19 @@ class HTMLPipelineTest < Minitest::Test
     # - mentions are linked
     assert_equal("<p><strong>yeH</strong>! I <em>think</em> <a href=\"http://your-domain.com/gjtorikian\" class=\"user-mention\">@gjtorikian</a> is <del>great</del>!</p>", result)
   end
+
+  def test_mention_and_team_mention_node_filters_are_applied
+    text = "Hey there, @billy. This one goes out to the @cool/dev team!"
+
+    pipeline = HTMLPipeline.new(
+      convert_filter: HTMLPipeline::ConvertFilter::MarkdownFilter.new,
+      node_filters: [
+        HTMLPipeline::NodeFilter::MentionFilter.new,
+        HTMLPipeline::NodeFilter::TeamMentionFilter.new
+      ],
+    )
+    result = pipeline.call(text)[:output]
+
+    assert_equal("<p>Hey there, <a href=\"/billy\" class=\"user-mention\">@billy</a>. This one goes out to the <a href=\"/cool/dev\" class=\"team-mention\">@cool/dev</a> team!</p>", result)
+  end
 end


### PR DESCRIPTION
I've been having trouble getting `MentionFilter` and `TeamMentionFilter` to both work together. (If only one is used, then it's correct, but when used in combination, it appears that only the second filter will be applied.)

Sorry for just sharing a failing test, but I wanted to demonstrate what I think the issue is. I've spent a few hours today trying to figure it out and I haven't found the root problem yet.